### PR TITLE
Fix role check in nav.php

### DIFF
--- a/Http/Forms/LoginForm.php
+++ b/Http/Forms/LoginForm.php
@@ -1,7 +1,7 @@
 <?php
 
-
 namespace Http\Forms;
+
 use Core\Validator;
 
 class LoginForm

--- a/Http/Forms/LoginForm.php
+++ b/Http/Forms/LoginForm.php
@@ -3,6 +3,7 @@
 
 namespace Http\Forms;
 use Core\Validator;
+
 class LoginForm
 {
     protected $errors = [];

--- a/views/partials/nav.php
+++ b/views/partials/nav.php
@@ -13,7 +13,7 @@
                         <?php if($_SESSION['user'] ?? false) :?>
                             <a href="/meetings" class="<?= urlIs('/meetings') ? 'bg-gray-900 text-white' : 'text-gray-300' ?> hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Meetings</a>
                         <?php endif?>
-                        <?php if(((int)($_SESSION['user']['user_role'] ?? null))=== \Core\UserRoles::ADMIN) :?>
+                        <?php if(((int)($_SESSION['user']['user_role'] ?? null)) === \Core\UserRoles::ADMIN) :?>
                             <a href="/students" class="<?= urlIs('/students') ? 'bg-gray-900 text-white' : 'text-gray-300' ?> hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Students</a>
                         <?php endif?>
 <!--                        <a href="/contact" class="--><?php //= urlIs('/contact') ? 'bg-gray-900 text-white' : 'text-gray-300' ?><!-- hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Contact</a>-->

--- a/views/partials/nav.php
+++ b/views/partials/nav.php
@@ -13,7 +13,7 @@
                         <?php if($_SESSION['user'] ?? false) :?>
                             <a href="/meetings" class="<?= urlIs('/meetings') ? 'bg-gray-900 text-white' : 'text-gray-300' ?> hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Meetings</a>
                         <?php endif?>
-                        <?php if(($_SESSION['user']['user_role'] ?? null) === \Core\UserRoles::ADMIN) :?>
+                        <?php if(((int)($_SESSION['user']['user_role'] ?? null))=== \Core\UserRoles::ADMIN) :?>
                             <a href="/students" class="<?= urlIs('/students') ? 'bg-gray-900 text-white' : 'text-gray-300' ?> hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Students</a>
                         <?php endif?>
 <!--                        <a href="/contact" class="--><?php //= urlIs('/contact') ? 'bg-gray-900 text-white' : 'text-gray-300' ?><!-- hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Contact</a>-->

--- a/views/students/index.view.php
+++ b/views/students/index.view.php
@@ -22,7 +22,6 @@ $table_row_style = 'border-e border-neutral-200 whitespace-nowrap px-6 py-4 font
                                 <thead
                                     class="border-b border-neutral-200 font-medium dark:border-black/20">
                                 <tr>
-                                    <th scope="col" class="w-0 <?= $table_headings_style ?>">No.</th>
                                     <th scope="col" class="w-0 <?= $table_headings_style ?>">Student</th>
                                     <th scope="col" class="w-0 text-center px-6 py-4">Action</th>
                                 </tr>
@@ -30,7 +29,6 @@ $table_row_style = 'border-e border-neutral-200 whitespace-nowrap px-6 py-4 font
                                 <tbody>
                                 <?php foreach ($students as $index => $student) : ?>
                                     <tr class="border-b border-neutral-200 dark:border-black/10">
-                                        <td class="<?= $table_row_style ?>"><?= $index + 1 ?></td>
                                         <td class="<?= $table_row_style ?>">
                                             <?= htmlspecialchars($student['fname']) ?>
                                         </td>


### PR DESCRIPTION
1. При проверке роли из сессии - сравнение возвращало false потому что в $_SESSION['user']['user_role'] записывается роль с типом string, а константа \Core\UserRoles::ADMIN это integer. Так как используется строгое сравнение `===` оно не совпадало. 
Как решение - кастим значение из сессии тоже в int. 

2. Поправил форматирование LoginForm. Между namespace, "use" ипмортами и названием класса - должно быть по **одной** пустой строке. Ни больше ни меньше. Оно будет работать да, но IDE его не видит и когда подключим composer тоже будет куча ошибок. Короче это нужно просто запомнить.
![image](https://github.com/user-attachments/assets/19777deb-f669-4034-ae66-71e20d9cc9ec)


Так же убрал колонку No из таблицы студентов. 